### PR TITLE
WIP: Add support for DOECode .json input

### DIFF
--- a/scraper/code_gov/__init__.py
+++ b/scraper/code_gov/__init__.py
@@ -345,7 +345,9 @@ class CodeGovProject(dict):
         project['description'] = repository['description']
 
         # *license: [null or string] The URL of the project license, if available. null should be used if not.
-        project['license'] = ', '.join(repository['licenses'])
+        licenses = set(repository['licenses'])
+        licenses.discard(None)
+        project['license'] = ', '.join(licenses)
 
         # *openSourceProject: [integer] A value indicating whether or not the project is open source.
         #   0: The project is not open source.
@@ -384,7 +386,7 @@ class CodeGovProject(dict):
         project['vcs'] = 'git'
 
         # repository: [string] The URL of the public project repository
-        project['repository'] = repository['repository_link']
+        project['repository'] = repository.get('repository_link', '')
 
         # homepage: [string] The URL of the public project homepage
         project['homepage'] = ''

--- a/scraper/code_gov/__init__.py
+++ b/scraper/code_gov/__init__.py
@@ -324,3 +324,92 @@ class CodeGovProject(dict):
         # project['updated']['lastCommit'] = None
 
         return project
+
+    @classmethod
+    def from_doecode(klass, repository):
+        """
+        Create CodeGovProject object from DOECode formatted json file
+
+        Handles crafting Code.gov Project
+        """
+        if not isinstance(repository, dict):
+            raise TypeError('Repository must be a dict')
+
+        project = klass()
+
+        # *name: [string] The project name
+        project['name'] = repository['software_title']
+
+        # *description: [string] A description of the project
+        project['description'] = repository['description']
+
+        # *license: [null or string] The URL of the project license, if available. null should be used if not.
+        project['license'] = ', '.join(repository['licenses'])
+
+        # *openSourceProject: [integer] A value indicating whether or not the project is open source.
+        #   0: The project is not open source.
+        #   1: The project is open source.
+        project['openSourceProject'] = bool(repository['open_source'])
+
+        # *governmentWideReuseProject: [integer] A value indicating whether or not the project is built for government-wide reuse.
+        #   0: The project is not built for government-wide reuse.
+        #   1: The project is built for government-wide reuse.
+        project['governmentWideReuseProject'] = 0
+
+        # *tags: [array] A list of string alphanumeric keywords that identify the project.
+        project['tags'] = []
+
+        # *contact: [object] Information about contacting the project.
+        #   *email: [string] An email address to contact the project.
+        #   name: [string] The name of a contact or department for the project
+        #   twitter: [string] The username of the project's Twitter account
+        #   phone: [string] The phone number to contact a project.
+        project['contact'] = {
+            'email': repository['owner'],
+            'name': '',
+            'twitter': '',
+            'phone': '',
+        }
+
+        # status: [string] The development status of the project
+        #   "Ideation" - brainstorming phase.
+        #   "Alpha" - initial prototyping phase and internal testing.
+        #   "Beta" - a project is being tested in public.
+        #   "Production" - finished project, with development and maintenance ongoing.
+        #   "Archival" - finished project, but no longer actively maintained.
+        project['status'] = ''
+
+        # vcs: [string] A lowercase string with the name of the Version Control System in use on the project.
+        project['vcs'] = 'git'
+
+        # repository: [string] The URL of the public project repository
+        project['repository'] = repository['repository_link']
+
+        # homepage: [string] The URL of the public project homepage
+        project['homepage'] = ''
+
+        # downloadURL: [string] The URL where a distribution of the project can be found.
+        project['downloadURL'] = ''
+
+        # languages: [array] A list of strings with the names of the programming languages in use on the project.
+        project['languages'] = []
+
+        # partners: [array] A list of strings containing the acronyms of agencies partnering on the project.
+        project['partners'] = []
+
+        # exemption: [integer] The exemption that excuses the project from government-wide reuse.
+        #   1: The sharing of the source code is restricted by law or regulation, including—but not limited to—patent or intellectual property law, the Export Asset Regulations, the International Traffic in Arms Regulation, and the Federal laws and regulations governing classified information.
+        #   2: The sharing of the source code would create an identifiable risk to the detriment of national security, confidentiality of Government information, or individual privacy.
+        #   3: The sharing of the source code would create an identifiable risk to the stability, security, or integrity of the agency's systems or personnel.
+        #   4: The sharing of the source code would create an identifiable risk to agency mission, programs, or operations.
+        #   5: The CIO believes it is in the national interest to exempt sharing the source code.
+        project['exemption'] = None
+
+        # updated: [object] Dates that the project and metadata have been updated.
+        #   metadataLastUpdated: [string] A date in YYYY-MM-DD or ISO 8601 format indicating when the metadata in this file was last updated.
+        #   lastCommit: [string] A date in ISO 8601 format indicating when the last commit to the project repository was.
+        #   sourceCodeLastModified: [string] A field intended for closed-source software and software outside of a VCS. The date in YYYY-MM-DD or ISO 8601 format that the source code or package was last updated.
+        # project['updated']['metadataLastUpdated'] = None
+        # project['updated']['lastCommit'] = None
+
+        return project

--- a/scraper/code_gov/__init__.py
+++ b/scraper/code_gov/__init__.py
@@ -339,6 +339,7 @@ class CodeGovProject(dict):
 
         # *name: [string] The project name
         project['name'] = repository['software_title']
+        logger.debug('Software Title: %s', project['name'])
 
         # *description: [string] A description of the project
         project['description'] = repository['description']

--- a/scraper/gen_code_gov_json.py
+++ b/scraper/gen_code_gov_json.py
@@ -69,6 +69,16 @@ def process_bitbucket(bitbucket):
     return projects
 
 
+def process_doecode(doecode_json_filename):
+    """
+    Converts a DOECode .json file into DOECode projects
+    """
+    doecode_json = json.load(open(doecode_json_filename))
+    projects = [CodeGovProject.from_doecode(p) for p in doecode_json['records']]
+
+    return projects
+
+
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Process some integers.')
@@ -82,6 +92,8 @@ if __name__ == '__main__':
     parser.add_argument('--github-repos', type=str, nargs='+', default=[], help='GitHub Repositories')
 
     parser.add_argument('--to-csv', action='store_true', help='Toggle output to CSV')
+
+    parser.add_argument('--doecode-json', type=str, nargs='?', default='', help='Path to DOECode .json file')
 
     args = parser.parse_args()
 
@@ -107,6 +119,8 @@ if __name__ == '__main__':
     bitbucket_servers = config_json.get('bitbucket_servers', [])
     bitbucket_servers = [connect_to_bitbucket(s) for s in bitbucket_servers]
 
+    doecode_json = args.doecode_json
+
     logger.debug('Agency: %s', agency)
     logger.debug('Organization: %s', organization)
     logger.debug('GitHub.com Organizations: %s', github_orgs)
@@ -122,6 +136,8 @@ if __name__ == '__main__':
 
     for bitbucket in bitbucket_servers:
         code_json['projects'].extend(process_bitbucket(bitbucket))
+
+    code_json['projects'].extend(process_doecode(doecode_json))
 
     str_org_projects = code_json.to_json()
     print(str_org_projects)

--- a/scraper/gen_code_gov_json.py
+++ b/scraper/gen_code_gov_json.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Process some integers.')
 
     parser.add_argument('--agency', type=str, nargs='?', default='', help='Agency Label, e.g. "DOE"')
-    parser.add_argument('--organization', type=str, nargs='?', default='', help='Organization Name')
+    parser.add_argument('--method', type=str, nargs='?', default='', help='Method of measuring open source')
 
     parser.add_argument('--config', type=str, nargs='?', default='', help='Configuration File (*.json)')
 
@@ -94,6 +94,8 @@ if __name__ == '__main__':
     parser.add_argument('--to-csv', action='store_true', help='Toggle output to CSV')
 
     parser.add_argument('--doecode-json', type=str, nargs='?', default='', help='Path to DOECode .json file')
+
+    parser.add_argument('--verbose', action='store_true', help='Enable verbose output')
 
     args = parser.parse_args()
 
@@ -107,8 +109,8 @@ if __name__ == '__main__':
     agency = config_json.get('agency', 'UNKNOWN')
     agency = args.agency or agency
 
-    organization = config_json.get('organization', 'UNKNOWN')
-    organization = args.organization or organization
+    method = config_json.get('method', 'other')
+    method = args.method or method
 
     github_orgs = config_json.get('github_orgs', [])
     github_orgs.extend(args.github_orgs)
@@ -122,33 +124,34 @@ if __name__ == '__main__':
     doecode_json = args.doecode_json
 
     logger.debug('Agency: %s', agency)
-    logger.debug('Organization: %s', organization)
     logger.debug('GitHub.com Organizations: %s', github_orgs)
     logger.debug('GitHub.com Repositories: %s', github_repos)
 
-    code_json = CodeGovMetadata(agency, organization)
+    code_json = CodeGovMetadata(agency, method)
 
     for org_name in github_orgs:
-        code_json['projects'].extend(process_organization(org_name))
+        code_json['releases'].extend(process_organization(org_name))
 
     for repo_name in github_repos:
-        code_json['projects'].append(process_repository(repo_name))
+        code_json['releases'].append(process_repository(repo_name))
 
     for bitbucket in bitbucket_servers:
-        code_json['projects'].extend(process_bitbucket(bitbucket))
+        code_json['releases'].extend(process_bitbucket(bitbucket))
 
-    code_json['projects'].extend(process_doecode(doecode_json))
+    code_json['releases'].extend(process_doecode(doecode_json))
 
     str_org_projects = code_json.to_json()
-    print(str_org_projects)
+
+    if args.verbose:
+        print(str_org_projects)
+
     with open('code.json', 'w') as fp:
         fp.write(str_org_projects)
 
     if args.to_csv:
         with open('code.csv', 'w') as fp:
-            for project in code_json['projects']:
+            for project in code_json['releases']:
                 fp.write(to_doe_csv(project) + '\n')
 
     logger.info('Agency: %s', agency)
-    logger.info('Organization: %s', organization)
-    logger.info('Number of Projects: %s', len(code_json['projects']))
+    logger.info('Number of Projects: %s', len(code_json['releases']))


### PR DESCRIPTION
This will provide a mechanism to use scraper to import a DOECode formatted .json file, which will be at least one of the inputs into the eventual energy.gov/code.json file.