### PR TITLE
US Government GitHub

### DIFF
--- a/scraper/gen_code_gov_json.py
+++ b/scraper/gen_code_gov_json.py
@@ -75,12 +75,14 @@ def process_organization(org_name):
     """
     Returns a Code.gov standard JSON of GitHub organization projects
     """
-
-    _check_api_limits()
-
     org = gh.organization(org_name)
     repos = org.repositories(type='public')
     num_repos = org.public_repos_count
+
+    WIGGLE_ROOM = 100
+    num_requests_needed = 2 * num_repos + WIGGLE_ROOM
+
+    _check_api_limits(min_requests_remaining=num_requests_needed)
 
     logger.info('Processing GitHub Org: %s (%d public repos)', org_name, num_repos)
 

--- a/scraper/gen_code_gov_json.py
+++ b/scraper/gen_code_gov_json.py
@@ -6,6 +6,7 @@ import getpass
 import json
 import logging
 import os
+import time
 
 import github3
 import stashy

--- a/scraper/gen_code_gov_json.py
+++ b/scraper/gen_code_gov_json.py
@@ -72,6 +72,7 @@ def _check_api_limits(min_requests_remaining=250, sleep_time=15):
 
     return
 
+
 def process_organization(org_name):
     """
     Returns a Code.gov standard JSON of GitHub organization projects

--- a/scraper/gen_code_gov_json.py
+++ b/scraper/gen_code_gov_json.py
@@ -146,12 +146,12 @@ def government_at_github():
     us_gov_github_orgs = set()
 
     gov_yml = requests.get('https://raw.githubusercontent.com/github/government.github.com/gh-pages/_data/governments.yml')
-    gov_yml_json = yaml.load(gov_yml.text)
+    gov_yml_json = yaml.safe_load(gov_yml.text)
     us_gov_github_orgs.update(gov_yml_json['U.S. Federal'])
     us_gov_github_orgs.update(gov_yml_json['U.S. Military and Intelligence'])
 
     gov_labs_yml = requests.get('https://raw.githubusercontent.com/github/government.github.com/gh-pages/_data/research.yml')
-    gov_labs_yml_json = yaml.load(gov_labs_yml.text)
+    gov_labs_yml_json = yaml.safe_load(gov_labs_yml.text)
     us_gov_github_orgs.update(gov_labs_yml_json['U.S. Research Labs'])
 
     return list(us_gov_github_orgs)

--- a/scraper/gen_code_gov_json.py
+++ b/scraper/gen_code_gov_json.py
@@ -222,13 +222,13 @@ def main():
 
     code_json = CodeGovMetadata(agency, method)
 
-    for org_name in github_orgs:
+    for org_name in sorted(github_orgs, key=str.lower):
         code_json['releases'].extend(process_organization(org_name))
 
-    for repo_name in github_repos:
+    for repo_name in sorted(github_repos, key=str.lower):
         code_json['releases'].append(process_repository(repo_name))
 
-    for bitbucket in bitbucket_servers:
+    for bitbucket in sorted(bitbucket_servers, key=str.lower):
         code_json['releases'].extend(process_bitbucket(bitbucket))
 
     if os.path.isfile(doecode_json):


### PR DESCRIPTION
This pull request adds a command line flag `--github-gov-orgs` which leverages the public data from GitHub.com/community about U.S. Government GitHub organizations and allows for the creation of a single Code.gov `code.json` file with all of the data in it.

As of this pull request, this uses includes data from 252 GitHub organization, resulting in a combined 8716 open source US Government repositories.

The biggest stumbling block here is with the GitHub REST API, which only allows 5000 requests per hour, and at 2 requests per repository, I had to add some spinning logic to the processing to wait for my rate limit to recharge. I will be working with @LRWeber on converting this to the GraphQL API, which should drop the time it takes to generate (currently was about 3.5 hours).

cc/ @jcastle, @AlvandSalehi, @RicardoAReyes, @konklone, @h-m-f-t, @jbjonesjr, @dinatale2, @gonsie, @benbalter -- As this might be of interest, and / or is something that we've discussed.

One question, mostly for @jcastle, et al is -- What are the right "categories" to use from the GitHub Government Community? Currently, I'm only using the following from the [governments.yml](https://raw.githubusercontent.com/github/government.github.com/gh-pages/_data/governments.yml) and [research.yml](https://raw.githubusercontent.com/github/government.github.com/gh-pages/_data/research.yml) datasets:

- U.S. Federal
- U.S. Military and Intelligence
- U.S. Research Labs

Others which we might also want to include are:

- U.S. City
- U.S. County
- U.S. Special District
- U.S. States
- U.S. Tribal Nations

This is mostly an FYI style pull request, but if there are any comments or feedback, please send them my way!