### PR TITLE
adding license info for github, where exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ code.json
 build/
 dist/
 *.pyc
+llnl_scraper.egg-info/

--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -22,6 +22,7 @@ class Metadata(dict):
 
     For details: https://code.gov/#/policy-guide/docs/compliance/inventory-code
     """
+
     def __init__(self, agency, method, other_method=''):
         # *version: [string] The Code.gov metadata schema version
         self['version'] = '2.0.0'
@@ -193,7 +194,14 @@ class Project(dict):
         project['description'] = repository.description
 
         # TODO: Update licenses from GitHub API
-        project['permissions']['licenses'] = None
+        repo_license = repository.license()
+        if repo_license:
+            license = repo_license.license
+            if license:
+                logger.debug('license spdx=%s; url=%s', license['spdx_id'], license['url'])
+                project['permissions']['licenses'] = [license['url'], license['spdx_id']]
+            else:
+                project['permissions']['licenses'] = None
 
         public_server = repository.html_url.startswith('https://github.com')
         if not repository.private and public_server:


### PR DESCRIPTION
CDC wants to automatically capture license info where possible. Added these few lines to use github info where it's already in the response. Didn't add GitLab as that makes a separate http request to get license info.

Not sure if you wanted to parameterize this and you have two different ways (config file, and command line) so didn't add this in. But please let me know if you have a preference and I'll add parameters. Currently will ignore if no license info is available for repo.