### PR TITLE
github fixes, no URL if url is None, isoformat of only date, not time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 code.csv
 code.json
+config.json
 build/
 dist/
 *.pyc

--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -198,7 +198,7 @@ class Project(dict):
             license = repo_license.license
             if license:
                 logger.debug('license spdx=%s; url=%s', license['spdx_id'], license['url'])
-                if license['url'] == None:
+                if license['url'] is None:
                     project['permissions']['licenses'] = [{"name": license['spdx_id']}]
                 else:
                     project['permissions']['licenses'] = [{"URL": license['url'], "name":license['spdx_id']}]

--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -198,7 +198,10 @@ class Project(dict):
             license = repo_license.license
             if license:
                 logger.debug('license spdx=%s; url=%s', license['spdx_id'], license['url'])
-                project['permissions']['licenses'] = [license['url'], license['spdx_id']]
+                if license['url'] == None:
+                    project['permissions']['licenses'] = [{"name": license['spdx_id']}]
+                else:
+                    project['permissions']['licenses'] = [{"URL": license['url'], "name":license['spdx_id']}]
             else:
                 project['permissions']['licenses'] = None
 
@@ -252,8 +255,8 @@ class Project(dict):
         #   lastModified: [string] The date the release was modified, in YYYY-MM-DD or ISO 8601 format.
         #   metadataLastUpdated: [string] The date the metadata of the release was last updated, in YYYY-MM-DD or ISO 8601 format.
         project['date'] = {
-            'created': repository.pushed_at.isoformat(),
-            'lastModified': repository.updated_at.isoformat(),
+            'created': repository.pushed_at.date().isoformat(),
+            'lastModified': repository.updated_at.date().isoformat(),
             'metadataLastUpdated': '',
         }
 

--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -332,8 +332,8 @@ class Project(dict):
         # project['reusedCode'] = []
 
         project['date'] = {
-            'created': repository.created_at,
-            'lastModified': repository.last_activity_at,
+            'created': date_parse(repository.created_at).date().isoformat(),
+            'lastModified': date_parse(repository.last_activity_at).date().isoformat(),
             'metadataLastUpdated': '',
         }
 


### PR DESCRIPTION
Two schema validation fixes for github and one suggested change.

* Suggest adding config.json to .gitignore to reduce probability of accidentally checking in API tokens
* license should be an array of dictionaries, not just an array (i.e.
```json
"licenses": [
	"https://api.github.com/licenses/apache-2.0",
	"name": "Apache-2.0"
]
```
to
```json
"licenses": [
	{
		"URL": "https://api.github.com/licenses/apache-2.0",
		"name": "Apache-2.0"
	}
]
```
* created and lastModified should be YYYY-MM-DD or ISO8601 date format, not ISO8601 date and time (ie.
```2018-12-03``` not ```2018-12-03T23:03:34+00:00```

Found these validation errors when CDC generated and HHS ran our code.json through the [code.gov json validator](https://code.gov/about/compliance/inventory-code/validate-schema)
