### PR TITLE
Add support for Gitlab languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The basic structure is:
     {
         "url": "https://gitlab.com",    # GitLab.com or hosted GitLab instance URL to inventory
         "token": null,                  # Private token for accessing this GitHub instance
+        "fetch_languages": false,       # Include individual calls to API for language metadata. Very slow, so defaults to false. (eg, for 191 projects on internal server, 5 seconds for False, 12 minutes, 38 seconds for True)
 
         "orgs": [ ... ],    # List of organizations to inventory
         "repos": [ ... ],   # List of single repositories to inventory

--- a/demo.json
+++ b/demo.json
@@ -34,7 +34,7 @@
         {
             "url": "https://gitlab.com",
             "token": null,
-            "include_languages": false,
+            "fetch_languages": false,
 
             "repos": [
                 "IanLee1521/flake8",

--- a/demo.json
+++ b/demo.json
@@ -34,6 +34,7 @@
         {
             "url": "https://gitlab.com",
             "token": null,
+            "include_languages": false,
 
             "repos": [
                 "IanLee1521/flake8",

--- a/scraper/code_gov/__init__.py
+++ b/scraper/code_gov/__init__.py
@@ -67,6 +67,7 @@ def process_config(config):
         # public_only = instance.get('public_only', True)
         excluded = instance.get('exclude', [])
         token = instance.get('token', None)
+        fetch_languages = instance.get('fetch_languages', False)
 
         gl_session = gitlab.connect(url, token)
 
@@ -77,7 +78,7 @@ def process_config(config):
                 logger.info('Excluding: %s', repo.path_with_namespace)
                 continue
 
-            code_gov_project = Project.from_gitlab(repo, labor_hours=compute_labor_hours)
+            code_gov_project = Project.from_gitlab(repo, labor_hours=compute_labor_hours, languages=fetch_languages)
             code_gov_metadata['releases'].append(code_gov_project)
 
     # Parse config for Bitbucket repositories

--- a/scraper/code_gov/__init__.py
+++ b/scraper/code_gov/__init__.py
@@ -78,7 +78,7 @@ def process_config(config):
                 logger.info('Excluding: %s', repo.path_with_namespace)
                 continue
 
-            code_gov_project = Project.from_gitlab(repo, labor_hours=compute_labor_hours, languages=fetch_languages)
+            code_gov_project = Project.from_gitlab(repo, labor_hours=compute_labor_hours, fetch_languages=fetch_languages)
             code_gov_metadata['releases'].append(code_gov_project)
 
     # Parse config for Bitbucket repositories

--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -345,7 +345,7 @@ class Project(dict):
         project['downloadURL'] = api_url + archive_suffix
 
         # project['languages'] = [l for l, _ in repository.languages()]
-        
+
         if languages:
             project['languages'] = [*repository.languages()]
 

--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -283,7 +283,7 @@ class Project(dict):
         return project
 
     @classmethod
-    def from_gitlab(klass, repository, labor_hours=True, languages=False):
+    def from_gitlab(klass, repository, labor_hours=True, fetch_languages=False):
         """
         Create CodeGovProject object from GitLab Repository
         """
@@ -346,7 +346,7 @@ class Project(dict):
 
         # project['languages'] = [l for l, _ in repository.languages()]
 
-        if languages:
+        if fetch_languages:
             project['languages'] = [*repository.languages()]
 
         # project['partners'] = []

--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -283,7 +283,7 @@ class Project(dict):
         return project
 
     @classmethod
-    def from_gitlab(klass, repository, labor_hours=True):
+    def from_gitlab(klass, repository, labor_hours=True, languages=False):
         """
         Create CodeGovProject object from GitLab Repository
         """
@@ -345,6 +345,10 @@ class Project(dict):
         project['downloadURL'] = api_url + archive_suffix
 
         # project['languages'] = [l for l, _ in repository.languages()]
+        
+        if languages:
+            project['languages'] = [*repository.languages()]
+
         # project['partners'] = []
         # project['relatedCode'] = []
         # project['reusedCode'] = []


### PR DESCRIPTION
This request includes support for reading language metadata for GitLab projects. Unfortunately, the GitLab api requires a separate call out to each project to read the APIs and that can take a while. One of my GitLab servers went from 5 seconds to 13 minutes. So I added a config setting for GitLab configs for fetch_languages and defaulted it to false. This should protect current users of GitLab from experiencing slowdowns.

Happy to refactor to default to true if you have a preference.

I noticed this behavior when trying to compare language use across projects and saw that only GitHub projects had the languages tab populated.