### PR TITLE
Fix date comparison for GitHub

### DIFF
--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -214,7 +214,7 @@ class Project(dict):
         public_server = repository.html_url.startswith('https://github.com')
         if not repository.private and public_server:
             project['permissions']['usageType'] = 'openSource'
-        elif date_parse(repository.created_at) < POLICY_START_DATE:
+        elif repository.created_at < POLICY_START_DATE:
             project['permissions']['usageType'] = 'exemptByPolicyDate'
 
         if labor_hours:


### PR DESCRIPTION
Resolves #30 

The issue was that [github3.py returns a `datetime`](https://github.com/sigmavirus24/github3.py/blob/master/src/github3/models.py#L88) for the `repository.created_at` property, but `dateutil.parser.parse` expects a string. So just skip the date parsing.

I don't know if any other repository platforms are affected; only tested GitHub.