### PR TITLE
GitHub Headers

### DIFF
--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -247,7 +247,7 @@ class Project(dict):
 
         project["downloadURL"] = repository.downloads_url
 
-        project["languages"] = [l for l, _ in repository.languages()]
+        project["languages"] = [lang for lang, _ in repository.languages()]
 
         # project['partners'] = []
 
@@ -337,7 +337,7 @@ class Project(dict):
         archive_suffix = "/projects/%s/repository/archive" % repository.get_id()
         project["downloadURL"] = api_url + archive_suffix
 
-        # project['languages'] = [l for l, _ in repository.languages()]
+        # project['languages'] = [lang for lang, _ in repository.languages()]
 
         if fetch_languages:
             project["languages"] = [*repository.languages()]

--- a/scraper/github/queryManager.py
+++ b/scraper/github/queryManager.py
@@ -143,7 +143,7 @@ class GitHubQueryManager:
             self.__query = query_in
         return query_in
 
-    def queryGitHubFromFile(self, filePath, gitvars={}, verbosity=0, **kwargs):
+    def queryGitHubFromFile(self, filePath, gitvars=None, verbosity=0, **kwargs):
         """Submit a GitHub GraphQL query from a file.
 
         Can only be used with GraphQL queries.
@@ -156,7 +156,7 @@ class GitHubQueryManager:
                 .. _GitHub GraphQL Explorer:
                    https://developer.github.com/v4/explorer/
             gitvars (Optional[Dict]): All query variables.
-                Defaults to empty.
+                Defaults to None.
                 GraphQL Only.
             verbosity (Optional[int]): Changes output verbosity levels.
                 If < 0, all extra printouts are suppressed.
@@ -169,6 +169,9 @@ class GitHubQueryManager:
             Dict: A JSON style dictionary.
 
         """
+        if not gitvars:
+            gitvars = {}
+
         gitquery = self._readGQL(filePath, verbose=(verbosity >= 0))
         return self.queryGitHub(
             gitquery, gitvars=gitvars, verbosity=verbosity, **kwargs
@@ -177,15 +180,15 @@ class GitHubQueryManager:
     def queryGitHub(
         self,
         gitquery,
-        gitvars={},
+        gitvars=None,
         verbosity=0,
         paginate=False,
         cursorVar=None,
-        keysToList=[],
+        keysToList=None,
         rest=False,
         requestCount=0,
         pageNum=0,
-        headers={},
+        headers=None,
     ):
         """Submit a GitHub query.
 
@@ -195,7 +198,7 @@ class GitHubQueryManager:
                        query: 'query { viewer { login } }'
                     endpoint: '/user'
             gitvars (Optional[Dict]): All query variables.
-                Defaults to empty.
+                Defaults to None.
                 GraphQL Only.
             verbosity (Optional[int]): Changes output verbosity levels.
                 If < 0, all extra printouts are suppressed.
@@ -209,7 +212,7 @@ class GitHubQueryManager:
                 GraphQL Only.
             keysToList (Optional[List[str]]): Ordered list of keys needed to
                 retrieve the list in the query results to be extended by
-                pagination. Defaults to empty.
+                pagination. Defaults to None.
                 Example:
                     ['data', 'viewer', 'repositories', 'nodes']
                 GraphQL Only.
@@ -219,12 +222,19 @@ class GitHubQueryManager:
             pageNum (Optional[int]): Counter for pagination.
                 For user readable log messages only, does not affect data.
             headers (Optional[Dict]): Additional headers.
-                Defaults to empty.
+                Defaults to None.
 
         Returns:
             Dict: A JSON style dictionary.
 
         """
+        if not gitvars:
+            gitvars = {}
+        if not keysToList:
+            keysToList = []
+        if not headers:
+            headers = {}
+
         requestCount += 1
         pageNum = 0 if pageNum < 0 else pageNum  # no negative page numbers
         pageNum += 1
@@ -437,7 +447,9 @@ class GitHubQueryManager:
 
         return outObj
 
-    def _submitQuery(self, gitquery, gitvars={}, verbose=False, rest=False, headers={}):
+    def _submitQuery(
+        self, gitquery, gitvars=None, verbose=False, rest=False, headers=None
+    ):
         """Send a curl request to GitHub.
 
         Args:
@@ -446,13 +458,13 @@ class GitHubQueryManager:
                        query: 'query { viewer { login } }'
                     endpoint: '/user'
             gitvars (Optional[Dict]): All query variables.
-                Defaults to empty.
+                Defaults to None.
             verbose (Optional[bool]): If False, stderr prints will be
                 suppressed. Defaults to False.
             rest (Optional[bool]): If True, uses the REST API instead
                 of GraphQL. Defaults to False.
             headers (Optional[Dict]): Additional headers.
-                Defaults to empty.
+                Defaults to None.
 
         Returns:
             {
@@ -463,6 +475,11 @@ class GitHubQueryManager:
             }
 
         """
+        if not gitvars:
+            gitvars = {}
+        if not headers:
+            headers = {}
+
         authhead = {"Authorization": "bearer " + self.__githubApiToken}
         if not rest:
             gitqueryJSON = json.dumps(


### PR DESCRIPTION
You can now include additional headers in GitHub queries.
This enables the use of API schema "previews". (https://docs.github.com/en/graphql/overview/schema-previews)