### PR TITLE
Update `cocomo_url`, USC reference links

### DIFF
--- a/scraper/util.py
+++ b/scraper/util.py
@@ -148,7 +148,7 @@ def compute_labor_hours(sloc, month_hours="cocomo_book"):
     The intention is to use the COCOMO II model to compute this value.
 
     References:
-    - https://csse.usc.edu/tools/cocomoii.php
+    - http://csse.usc.edu/tools
     - http://docs.python-guide.org/en/latest/scenarios/scrape/
     """
     # Calculation of hours in a month
@@ -163,7 +163,7 @@ def compute_labor_hours(sloc, month_hours="cocomo_book"):
         # https://github.com/GSA/code-gov/blob/master/LABOR_HOUR_CALC.md
         HOURS_PER_PERSON_MONTH = 152.0
 
-    cocomo_url = "https://csse.usc.edu/tools/cocomoii.php"
+    cocomo_url = "http://softwarecost.org/tools/COCOMO/"
     page = requests.post(cocomo_url, data={"new_size": sloc})
 
     try:


### PR DESCRIPTION
Resolves #55

The [old COCOMO II link](https://csse.usc.edu/tools/cocomoii.php) no longer loads. 

- For `cocomo_url`, use the [softwarecost.org](http://softwarecost.org/tools/COCOMO/) linked on the [USC site](http://csse.usc.edu/tools).  
- Update the USC reference link (note: doesn't worth with https - http only)

Thanks!