### PR TITLE
Test CPython and fix package version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 'pypy3.6', "pypy3.7", "pypy3.8", "pypy3.9"]
+        python-version:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - pypy3.6
+          - pypy3.7
+          - pypy3.8
+          - pypy3.9
     name: Python ${{ matrix.python-version }} Tests
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.6"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements/production.txt") as fp:
 
 setup(
     name="llnl-scraper",
-    version="0.10.1",
+    version="0.11.0",
     description="Package for extracting software repository metadata",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements/production.txt") as fp:
 
 setup(
     name="llnl-scraper",
-    version="0.11.0",
+    version="0.11.0-dev",
     description="Package for extracting software repository metadata",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This pull request adds CPython (3.6-3.10) to the matrix of Python versions tested in the GitHub Actions workflow. This will help ensure that everything works as expected against the typical Python installation of end users. It also disabled fail-fast behavior in the job strategy so that all version finish testing regardless of any failures in other versions.

I also updated the version of the package to reflect the current versions found on [PyPI](https://pypi.org/project/llnl-scraper/).