### PR TITLE
Calculate person-months of effort in the package

### DIFF
--- a/scraper/util.py
+++ b/scraper/util.py
@@ -158,7 +158,7 @@ def compute_labor_hours(sloc, month_hours="cocomo_book"):
         # Use value from COCOMO II Book (month_hours=='cocomo_book'):
         # Reference: https://dl.acm.org/citation.cfm?id=557000
         # This is the value used by the Code.gov team:
-        # https://github.com/GSA/code-gov/blob/master/LABOR_HOUR_CALC.md
+        # https://github.com/GSA/code-gov/blob/master/docs/labor_hour_calc.md
         HOURS_PER_PERSON_MONTH = 152.0
 
     # Coefficients for the COCOMO II model (only the two used for person-month


### PR DESCRIPTION
This pull request changes the calculation of person-months from relying on the tool located at http://softwarecost.org/tools/COCOMO/ to calculating it within the package using the same settings. The labor hours calculation is rounded to the tenths to be consistent with the output of the previous method.

If there is an issue with connecting to the above tool it will cause an unrecoverable failure when using this tool from the CLI. This is especially painful if working over a large number of projects. Since this is a relatively straightforward calculation I thought it prudent to just implement calculating person-months in the package to remove the need to query the tool entirely.

**Note**: There is a difference in the calculated labor hours value because the above tool rounds the person-months output to the tenths while we have the raw value when calculating it locally. PHP (what the tool appears to be written in) has a default of `PHP_ROUND_HALF_UP` in the `round()` function which has the following description:
> Rounds num away from zero when it is half way there, making 1.5 into 2 and -1.5 into -2.

Using the CLOC of this branch:

```console
$ cloc --json . | jq '.SUM.code'
3152
```

Old implementation:

```console
>>> compute_labor_hours(3152)
1580.8
```

Person-months: 10.4

New implementation:

```console
>>> compute_labor_hours(3152)
1579.4
```

Person-months: 10.390646842135041
