### PR TITLE
Use `black` on the entire project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test:
 	bandit -r scraper/
 	flake8 scraper/
-	black --check scraper/
+	black --check .
 	markdownlint '**/*.md'
 	pyflakes scraper
 

--- a/scripts/org_to_emails.py
+++ b/scripts/org_to_emails.py
@@ -11,10 +11,10 @@ def print_org_members_without_2fa(org_name="llnl"):
 
     for user in org.members(filter="2fa_disabled"):
         emails = {
-            c['author']['email']
+            c["author"]["email"]
             for e in user.events()
             if e.type == "PushEvent"
-            for c in e.payload['commits']
+            for c in e.payload["commits"]
         }
         emails = {e for e in emails if "@llnl.gov" in e}
         if emails:

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,14 @@ setup(
     url="https://github.com/llnl/scraper",
     packages=find_packages(),
     install_requires=install_reqs,
-    entry_points={"console_scripts": ["scraper = scraper.gen_code_gov_json:main",]},
-    scripts=["scripts/codegov_compute_hours.py",],
+    entry_points={
+        "console_scripts": [
+            "scraper = scraper.gen_code_gov_json:main",
+        ]
+    },
+    scripts=[
+        "scripts/codegov_compute_hours.py",
+    ],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This pull request just expands the scope of `black` checking to cover the entire project. This ensures that any Python code in the project has the same formatting.