### PR TITLE
Add the `isort` tool to the test suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           conda create --quiet --name test pytest
           export PATH="/usr/share/miniconda/bin:$PATH"
           source activate test
-          pip install flake8 bandit black
+          pip install bandit black isort flake8
           pip install .
           npm install -g markdownlint-cli@0.23.2        
           make test

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ test:
 	bandit -r scraper/
 	flake8 scraper/
 	black --check scraper/
+	isort --check .
 	markdownlint '**/*.md'
 	pyflakes scraper
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,5 +8,6 @@ twine
 bandit
 black
 flake8
-safety
+isort
 pyflakes
+safety

--- a/scraper/bitbucket/__init__.py
+++ b/scraper/bitbucket/__init__.py
@@ -1,8 +1,7 @@
-import logging
-import stashy
-
 import datetime
+import logging
 
+import stashy
 from stashy.client import Stash
 
 logger = logging.getLogger(__name__)

--- a/scraper/code_gov/__init__.py
+++ b/scraper/code_gov/__init__.py
@@ -3,9 +3,9 @@
 
 import logging
 
+from scraper import bitbucket, doecode, github, gitlab, tfs
 from scraper.code_gov.models import Metadata, Project
 from scraper.github import gov_orgs
-from scraper import github, gitlab, bitbucket, doecode, tfs
 
 logger = logging.getLogger(__name__)
 

--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -5,9 +5,9 @@ import json
 import logging
 
 from dateutil.parser import parse as date_parse
-from requests.utils import requote_uri
 import github3
 import gitlab
+from requests.utils import requote_uri
 
 from scraper.github.util import _license_obj
 from scraper.util import _prune_dict_null_str, labor_hours_from_url

--- a/scraper/github/__init__.py
+++ b/scraper/github/__init__.py
@@ -3,10 +3,10 @@
 
 import logging
 import os
-
-import requests
-import github3
 import time
+
+import github3
+import requests
 
 logger = logging.getLogger(__name__)
 

--- a/scraper/github/queryManager.py
+++ b/scraper/github/queryManager.py
@@ -5,13 +5,14 @@ With this module, you will be able to send GraphQL and REST queries
 to GitHub, as well as read and write JSON files to store data.
 """
 
+from datetime import datetime
 import json
 import os
-import pytz
 import re
-import requests
 import time
-from datetime import datetime
+
+import pytz
+import requests
 
 
 def _vPrint(verbose, *args, **kwargs):

--- a/scraper/tfs/__init__.py
+++ b/scraper/tfs/__init__.py
@@ -4,8 +4,9 @@
 import logging
 import os
 
-from vsts.vss_connection import VssConnection
 from msrest.authentication import BasicAuthentication
+from vsts.vss_connection import VssConnection
+
 from scraper.tfs.models import TFSProject
 
 logger = logging.getLogger(__name__)

--- a/scraper/util.py
+++ b/scraper/util.py
@@ -3,9 +3,8 @@ import json
 import logging
 import logging.config
 import os
+from subprocess import PIPE, STDOUT, Popen  # nosec
 import tempfile
-
-from subprocess import Popen, PIPE, STDOUT  # nosec
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/codegov_compute_hours.py
+++ b/scripts/codegov_compute_hours.py
@@ -5,7 +5,6 @@ import json
 
 from scraper.util import compute_labor_hours, git_repo_to_sloc
 
-
 parser = argparse.ArgumentParser(
     description="Scrape code repositories for Code.gov / DOECode"
 )

--- a/scripts/get_stargazers.py
+++ b/scripts/get_stargazers.py
@@ -1,7 +1,8 @@
-import github3
 import datetime
-import os
 import getpass
+import os
+
+import github3
 import requests
 
 

--- a/scripts/get_traffic.py
+++ b/scripts/get_traffic.py
@@ -1,14 +1,15 @@
-import github3
+import calendar
+import csv
 import datetime
-import os
 import errno
 import getpass
-import time
-import csv
-import math
 import json
+import math
+import os
+import time
+
+import github3
 import requests
-import calendar
 
 
 class GitHub_Traffic:

--- a/scripts/get_users_emails.py
+++ b/scripts/get_users_emails.py
@@ -1,6 +1,7 @@
-import github3
-import os
 import getpass
+import os
+
+import github3
 
 
 class GitHub_Users_Emails:

--- a/scripts/get_year_commits.py
+++ b/scripts/get_year_commits.py
@@ -1,8 +1,9 @@
-import github3
 import datetime
-import os
 import getpass
+import os
 import time
+
+import github3
 
 
 class GitHub_LLNL_Year_Commits:

--- a/scripts/github_stats.py
+++ b/scripts/github_stats.py
@@ -1,14 +1,15 @@
-import github3
+from collections import defaultdict
+import csv
 import datetime
-import os
 import errno
 import getpass
-import time
-import csv
-import math
-import my_repo
 import json
-from collections import defaultdict
+import math
+import os
+import time
+
+import github3
+import my_repo
 
 
 class GitHub_LLNL_Stats:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,7 @@
 [flake8]
 ignore = E231, E501, W503
+
+[isort]
+combine_star = true
+force_sort_within_sections = true
+profile = black

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open("README.md") as fh:
     long_description = fh.read()


### PR DESCRIPTION
This pull request adds the [isort](https://github.com/PyCQA/isort) tool to the test suite for the project. This will ensure that imports in the project are automatically sorted and there is a clear separation between different types of imports (standard library/third-party/internal). This would just improve the maintainability of the code base by keep imports organized and ensuring there is no overlap or duplication.