### PR TITLE
Improve process output handling and streamline `cloc` JSON parsing

### DIFF
--- a/scraper/util.py
+++ b/scraper/util.py
@@ -135,9 +135,7 @@ def git_repo_to_sloc(url):
         out = execute(cmd)
 
         try:
-            json_start = out.find('{"header"')
-            json_blob = out[json_start:].replace("\\n", "").replace("'", "")
-            cloc_json = json.loads(json_blob)
+            cloc_json = json.loads(out)
             sloc = cloc_json["SUM"]["code"]
         except json.decoder.JSONDecodeError:
             logger.error("Error Decoding: url=%s, out=%s", url, out)


### PR DESCRIPTION
This pull request improves how the `scraper.util.execute()` function handles process output. With this improved output handling we can also streamline processing the JSON output of the `cloc` command in the `scraper.util.git_repo_to_sloc()` function.