### PR TITLE
Code cleanups based on `pylint` linting

### DIFF
--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -193,14 +193,16 @@ class Project(dict):
             repo_license = None
 
         if repo_license:
-            license = repo_license.license
-            if license:
-                logger.debug("license spdx=%s; url=%s", license.spdx_id, license.url)
-                if license.url is None:
-                    project["permissions"]["licenses"] = [{"name": license.spdx_id}]
+            license_obj = repo_license.license
+            if license_obj:
+                logger.debug(
+                    "license spdx=%s; url=%s", license_obj.spdx_id, license_obj.url
+                )
+                if license_obj.url is None:
+                    project["permissions"]["licenses"] = [{"name": license_obj.spdx_id}]
                 else:
                     project["permissions"]["licenses"] = [
-                        {"URL": license.url, "name": license.spdx_id}
+                        {"URL": license_obj.url, "name": license_obj.spdx_id}
                     ]
             else:
                 project["permissions"]["licenses"] = None
@@ -478,7 +480,9 @@ class Project(dict):
             license_objects = [{"name": "Other", "URL": record["proprietary_url"]}]
 
         if licenses:
-            license_objects.extend([_license_obj(license) for license in licenses])
+            license_objects.extend(
+                [_license_obj(license_name) for license_name in licenses]
+            )
 
         project["permissions"]["licenses"] = license_objects
 

--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -524,12 +524,8 @@ class Project(dict):
         status = record.get("ever_announced")
         if status is None:
             raise ValueError('DOE CODE: Unable to determine "ever_announced" value!')
-        elif status:
-            status = "Production"
-        else:
-            status = "Development"
 
-        project["status"] = status
+        project["status"] = "Production" if status else "Development"
 
         vcs = None
         link = project["repositoryURL"]

--- a/scraper/doecode/__init__.py
+++ b/scraper/doecode/__init__.py
@@ -14,7 +14,7 @@ def process_json(filename):
 
     logger.debug("Processing DOE CODE json: %s", filename)
 
-    with open(filename) as fd:
+    with open(filename, encoding="utf-8") as fd:
         doecode_json = json.load(fd)
 
     for record in doecode_json["records"]:

--- a/scraper/doecode/__init__.py
+++ b/scraper/doecode/__init__.py
@@ -14,7 +14,8 @@ def process_json(filename):
 
     logger.debug("Processing DOE CODE json: %s", filename)
 
-    doecode_json = json.load(open(filename))
+    with open(filename) as fd:
+        doecode_json = json.load(fd)
 
     for record in doecode_json["records"]:
         yield record

--- a/scraper/gen_code_gov_json.py
+++ b/scraper/gen_code_gov_json.py
@@ -101,7 +101,7 @@ def main():
     configure_logging(args.verbose)
 
     try:
-        with open(args.config) as fd:
+        with open(args.config, encoding="utf-8") as fd:
             config_json = json.load(fd)
     except (FileNotFoundError, json.JSONDecodeError):
         if args.config:

--- a/scraper/gen_code_gov_json.py
+++ b/scraper/gen_code_gov_json.py
@@ -101,7 +101,8 @@ def main():
     configure_logging(args.verbose)
 
     try:
-        config_json = json.load(open(args.config))
+        with open(args.config) as fd:
+            config_json = json.load(fd)
     except (FileNotFoundError, json.JSONDecodeError):
         if args.config:
             raise

--- a/scraper/github/__init__.py
+++ b/scraper/github/__init__.py
@@ -77,7 +77,7 @@ def _num_requests_needed(num_repos, factor=2, wiggle_room=100):
     return num_repos * factor + wiggle_room
 
 
-def _check_api_limits(gh_session, api_required=250, sleep_time=15):
+def _check_api_limits(gh_session, api_required=250):
     """
     Simplified check for API limits
 

--- a/scraper/github/__init__.py
+++ b/scraper/github/__init__.py
@@ -96,7 +96,7 @@ def _check_api_limits(gh_session, api_required=250):
 
     now_time = time.time()
     time_to_reset = int(api_reset - now_time)
-    logger.warn("Rate Limit Depleted - Sleeping for %d seconds", time_to_reset)
+    logger.warning("Rate Limit Depleted - Sleeping for %d seconds", time_to_reset)
 
     while now_time < api_reset:
         time.sleep(10)

--- a/scraper/github/__init__.py
+++ b/scraper/github/__init__.py
@@ -22,11 +22,15 @@ def gov_orgs():
     """
     us_gov_github_orgs = set()
 
-    gov_orgs = requests.get("https://government.github.com/organizations.json").json()
+    gov_orgs_json = requests.get(
+        "https://government.github.com/organizations.json"
+    ).json()
 
-    us_gov_github_orgs.update(gov_orgs["governments"]["U.S. Federal"])
-    us_gov_github_orgs.update(gov_orgs["governments"]["U.S. Military and Intelligence"])
-    us_gov_github_orgs.update(gov_orgs["research"]["U.S. Research Labs"])
+    us_gov_github_orgs.update(gov_orgs_json["governments"]["U.S. Federal"])
+    us_gov_github_orgs.update(
+        gov_orgs_json["governments"]["U.S. Military and Intelligence"]
+    )
+    us_gov_github_orgs.update(gov_orgs_json["research"]["U.S. Research Labs"])
 
     return list(us_gov_github_orgs)
 

--- a/scraper/github/queryManager.py
+++ b/scraper/github/queryManager.py
@@ -95,7 +95,7 @@ class GitHubQueryManager:
     @maxRetry.setter
     def maxRetry(self, maxRetry):
         numIn = int(maxRetry)
-        numIn = 1 if not numIn > 0 else numIn
+        numIn = 1 if numIn <= 0 else numIn
         self.__maxRetry = numIn
         print("Auto-retry limit for requests set to %d." % (self.maxRetry))
 
@@ -265,7 +265,7 @@ class GitHubQueryManager:
                 "reset": int(response["headDict"]["X-RateLimit-Reset"]),
             }
             _vPrint((verbosity >= 0), "API Status %s" % (json.dumps(apiStatus)))
-            if not apiStatus["remaining"] > 0:
+            if apiStatus["remaining"] <= 0:
                 _vPrint((verbosity >= 0), "API usage limit reached during query.")
                 self._awaitReset(apiStatus["reset"])
                 _vPrint((verbosity >= 0), "Repeating query...")

--- a/scraper/github/queryManager.py
+++ b/scraper/github/queryManager.py
@@ -25,9 +25,7 @@ def _vPrint(verbose, *args, **kwargs):
 
     """
     if verbose:
-        return print(*args, **kwargs)
-    else:
-        pass
+        print(*args, **kwargs)
 
 
 class GitHubQueryManager:

--- a/scraper/github/queryManager.py
+++ b/scraper/github/queryManager.py
@@ -129,7 +129,7 @@ class GitHubQueryManager:
             query_in = self.__query
         else:
             _vPrint(verbose, "Reading '%s' ... " % (filePath), end="", flush=True)
-            with open(filePath, "r") as q:
+            with open(filePath, "r", encoding="utf-8") as q:
                 # Strip comments.
                 query_in = re.sub(r"#.*(\n|\Z)", "\n", q.read())
                 # Condense whitespace.
@@ -646,7 +646,7 @@ class DataManager:
             end="",
             flush=True,
         )
-        with open(filePath, "r") as q:
+        with open(filePath, "r", encoding="utf-8") as q:
             data_raw = q.read()
         print("Imported!")
         self.data = json.loads(data_raw)
@@ -675,7 +675,7 @@ class DataManager:
                 os.makedirs(os.path.split(filePath)[0])
         dataJsonString = json.dumps(self.data, indent=4, sort_keys=True)
         print("Writing to file '%s' ... " % (filePath), end="", flush=True)
-        with open(filePath, "w", newline=newline) as fileout:
+        with open(filePath, "w", encoding="utf-8", newline=newline) as fileout:
             fileout.write(dataJsonString)
         print("Wrote file!")
         if updatePath:

--- a/scraper/github/queryManager.py
+++ b/scraper/github/queryManager.py
@@ -315,7 +315,7 @@ class GitHubQueryManager:
                 headers=headers,
             )
         # Check for server error responses
-        if statusNum == 502 or statusNum == 503:
+        if statusNum in (502, 503):
             if requestCount >= self.maxRetry:
                 raise RuntimeError(
                     "Query attempted but failed %d times.\n%s\n%s"

--- a/scraper/github/queryManager.py
+++ b/scraper/github/queryManager.py
@@ -70,8 +70,8 @@ class GitHubQueryManager:
                 "GitHub API token is not valid.\n%s %s"
                 % (basicCheck["statusTxt"], basicCheck["result"])
             )
-        else:
-            print("Token validated.")
+
+        print("Token validated.")
 
         # Initialize private variables
         self.__retryDelay = 3  #: Number of seconds to wait between retries.
@@ -296,24 +296,24 @@ class GitHubQueryManager:
                         response["result"],
                     )
                 )
-            else:
-                self._countdown(
-                    self.__retryDelay,
-                    printString="Query accepted but not yet processed. Trying again in %*dsec...",
-                    verbose=(verbosity >= 0),
-                )
-                return self.queryGitHub(
-                    gitquery,
-                    gitvars=gitvars,
-                    verbosity=verbosity,
-                    paginate=paginate,
-                    cursorVar=cursorVar,
-                    keysToList=keysToList,
-                    rest=rest,
-                    requestCount=requestCount,
-                    pageNum=pageNum,
-                    headers=headers,
-                )
+
+            self._countdown(
+                self.__retryDelay,
+                printString="Query accepted but not yet processed. Trying again in %*dsec...",
+                verbose=(verbosity >= 0),
+            )
+            return self.queryGitHub(
+                gitquery,
+                gitvars=gitvars,
+                verbosity=verbosity,
+                paginate=paginate,
+                cursorVar=cursorVar,
+                keysToList=keysToList,
+                rest=rest,
+                requestCount=requestCount,
+                pageNum=pageNum,
+                headers=headers,
+            )
         # Check for server error responses
         if statusNum == 502 or statusNum == 503:
             if requestCount >= self.maxRetry:
@@ -325,24 +325,24 @@ class GitHubQueryManager:
                         response["result"],
                     )
                 )
-            else:
-                self._countdown(
-                    self.__retryDelay,
-                    printString="Server error. Trying again in %*dsec...",
-                    verbose=(verbosity >= 0),
-                )
-                return self.queryGitHub(
-                    gitquery,
-                    gitvars=gitvars,
-                    verbosity=verbosity,
-                    paginate=paginate,
-                    cursorVar=cursorVar,
-                    keysToList=keysToList,
-                    rest=rest,
-                    requestCount=requestCount,
-                    pageNum=pageNum,
-                    headers=headers,
-                )
+
+            self._countdown(
+                self.__retryDelay,
+                printString="Server error. Trying again in %*dsec...",
+                verbose=(verbosity >= 0),
+            )
+            return self.queryGitHub(
+                gitquery,
+                gitvars=gitvars,
+                verbosity=verbosity,
+                paginate=paginate,
+                cursorVar=cursorVar,
+                keysToList=keysToList,
+                rest=rest,
+                requestCount=requestCount,
+                pageNum=pageNum,
+                headers=headers,
+            )
         # Check for other error responses
         if statusNum >= 400 or statusNum == 204:
             raise RuntimeError(
@@ -364,7 +364,8 @@ class GitHubQueryManager:
                         response["result"],
                     )
                 )
-            elif len(outObj["errors"]) == 1 and len(outObj["errors"][0]) == 1:
+
+            if len(outObj["errors"]) == 1 and len(outObj["errors"][0]) == 1:
                 # Poorly defined error type, usually intermittent, try again.
                 _vPrint(
                     (verbosity >= 0),
@@ -387,10 +388,10 @@ class GitHubQueryManager:
                     pageNum=pageNum,
                     headers=headers,
                 )
-            else:
-                raise RuntimeError(
-                    "GraphQL API error.\n%s" % (json.dumps(outObj["errors"]))
-                )
+
+            raise RuntimeError(
+                "GraphQL API error.\n%s" % (json.dumps(outObj["errors"]))
+            )
 
         # Re-increment page count before the next page query
         pageNum += 1
@@ -639,18 +640,18 @@ class DataManager:
             filePath = self.filePath
         if not os.path.isfile(filePath):
             raise FileNotFoundError("Data file '%s' does not exist." % (filePath))
-        else:
-            print(
-                "Importing existing data file '%s' ... " % (filePath),
-                end="",
-                flush=True,
-            )
-            with open(filePath, "r") as q:
-                data_raw = q.read()
-            print("Imported!")
-            self.data = json.loads(data_raw)
-            if updatePath:
-                self.filePath = filePath
+
+        print(
+            "Importing existing data file '%s' ... " % (filePath),
+            end="",
+            flush=True,
+        )
+        with open(filePath, "r") as q:
+            data_raw = q.read()
+        print("Imported!")
+        self.data = json.loads(data_raw)
+        if updatePath:
+            self.filePath = filePath
 
     def fileSave(self, filePath=None, updatePath=False, newline=None):
         """Write the internal JSON data dictionary to a JSON data file.

--- a/scraper/github/util.py
+++ b/scraper/github/util.py
@@ -3,7 +3,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def _license_obj(license):
+def _license_obj(license_name):
     """
     A helper function to look up license object information
 
@@ -11,46 +11,46 @@ def _license_obj(license):
     """
     obj = None
 
-    if license in ("MIT", "MIT License"):
+    if license_name in ("MIT", "MIT License"):
         obj = {"URL": "https://api.github.com/licenses/mit", "name": "MIT"}
-    elif license in ('BSD 2-clause "Simplified" License'):
+    elif license_name in ('BSD 2-clause "Simplified" License'):
         obj = {
             "URL": "https://api.github.com/licenses/bsd-2-clause",
             "name": "BSD-2-Clause",
         }
-    elif license in ('BSD 3-clause "New" or "Revised" License'):
+    elif license_name in ('BSD 3-clause "New" or "Revised" License'):
         obj = {
             "URL": "https://api.github.com/licenses/bsd-3-clause",
             "name": "BSD-3-Clause",
         }
-    elif license in ("Apache License 2.0"):
+    elif license_name in ("Apache License 2.0"):
         obj = {
             "URL": "https://api.github.com/licenses/apache-2.0",
             "name": "Apache-2.0",
         }
-    elif license in ("GNU General Public License v2.1"):
+    elif license_name in ("GNU General Public License v2.1"):
         obj = {"URL": "https://api.github.com/licenses/gpl-2.1", "name": "GPL-2.1"}
-    elif license in ("GNU General Public License v2.0"):
+    elif license_name in ("GNU General Public License v2.0"):
         obj = {"URL": "https://api.github.com/licenses/gpl-2.0", "name": "GPL-2.0"}
-    elif license in ("GNU Lesser General Public License v2.1"):
+    elif license_name in ("GNU Lesser General Public License v2.1"):
         obj = {"URL": "https://api.github.com/licenses/lgpl-2.1", "name": "LGPL-2.1"}
-    elif license in ("GNU General Public License v3.0"):
+    elif license_name in ("GNU General Public License v3.0"):
         obj = {"URL": "https://api.github.com/licenses/gpl-3.0", "name": "GPL-3.0"}
-    elif license in ("GNU Lesser General Public License v3.0"):
+    elif license_name in ("GNU Lesser General Public License v3.0"):
         obj = {"URL": "https://api.github.com/licenses/lgpl-3.0", "name": "LGPL-3.0"}
-    elif license in ("Eclipse Public License 1.0"):
+    elif license_name in ("Eclipse Public License 1.0"):
         obj = {"URL": "https://api.github.com/licenses/epl-1.0", "name": "EPL-1.0"}
-    elif license in ("Mozilla Public License 2.0"):
+    elif license_name in ("Mozilla Public License 2.0"):
         obj = {"URL": "https://api.github.com/licenses/mpl-2.0", "name": "MPL-2.0"}
-    elif license in ("The Unlicense"):
+    elif license_name in ("The Unlicense"):
         obj = {"URL": "https://api.github.com/licenses/unlicense", "name": "Unlicense"}
-    elif license in ("GNU Affero General Public License v3.0"):
+    elif license_name in ("GNU Affero General Public License v3.0"):
         obj = {"URL": "https://api.github.com/licenses/agpl-3.0", "name": "AGPL-3.0"}
-    elif license in ("Eclipse Public License 2.0"):
+    elif license_name in ("Eclipse Public License 2.0"):
         obj = {"URL": "https://api.github.com/licenses/epl-2.0", "name": "EPL-2.0"}
 
     if obj is None:
-        logger.warn("I don't understand the license: %s", license)
+        logger.warn("I don't understand the license: %s", license_name)
         raise ValueError("Aborting!")
 
     return obj

--- a/scraper/github/util.py
+++ b/scraper/github/util.py
@@ -50,7 +50,7 @@ def _license_obj(license_name):
         obj = {"URL": "https://api.github.com/licenses/epl-2.0", "name": "EPL-2.0"}
 
     if obj is None:
-        logger.warn("I don't understand the license: %s", license_name)
+        logger.warning("I don't understand the license: %s", license_name)
         raise ValueError("Aborting!")
 
     return obj

--- a/scraper/gitlab/__init__.py
+++ b/scraper/gitlab/__init__.py
@@ -20,8 +20,8 @@ def connect(url="https://gitlab.com", token=None):
 
     try:
         gl_session.version()
-    except (gitlab.exceptions.GitlabAuthenticationError):
-        raise RuntimeError("Invalid or missing GITLAB_API_TOKEN")
+    except gitlab.exceptions.GitlabAuthenticationError as exc:
+        raise RuntimeError("Invalid or missing GITLAB_API_TOKEN") from exc
 
     logger.info("Connected to: %s", url)
 

--- a/scraper/tfs/__init__.py
+++ b/scraper/tfs/__init__.py
@@ -124,11 +124,7 @@ def get_all_projects(url, token, top=HARD_CODED_TOP):
             token,
         )
 
-        logger.debug(
-            "Retrieving Projects for Project Collection: {collection_name}".format(
-                collection_name=collection.name
-            )
-        )
+        logger.debug("Retrieving Projects for Project Collection: %s", collection.name)
         # Retrieves all projects in the project collection
         projects = collection_client.get_projects(top=HARD_CODED_TOP)
         # get_projects only gets the project references, have to call get_project_history_entries to get last update info for projects
@@ -138,19 +134,13 @@ def get_all_projects(url, token, top=HARD_CODED_TOP):
 
             # get_projects only gets team project ref objects,
             # have to call get_project to get the team project object which includes the TFS Web Url for the project
-            logger.debug(
-                "Retrieving Team Project for Project: {project_name}".format(
-                    project_name=project.name
-                )
-            )
+            logger.debug("Retrieving Team Project for Project: %s", project.name)
             projectInfo = collection_client.get_project(project.id, True, True)
 
             tfsProject = TFSProject(projectInfo, collection)
 
             logger.debug(
-                "Retrieving Last Updated and Created Info for Project: {project_name}".format(
-                    project_name=project.name
-                )
+                "Retrieving Last Updated and Created Info for Project: %s", project.name
             )
             tfsProject.projectLastUpdateInfo = get_project_last_update_time(
                 collection_history_list, project.id
@@ -171,11 +161,7 @@ def get_git_repos(url, token, collection, project):
         "{url}/{collection_name}".format(url=url, collection_name=collection.name),
         token,
     )
-    logger.debug(
-        "Retrieving Git Repos for Project: {project_name}".format(
-            project_name=project.name
-        )
-    )
+    logger.debug("Retrieving Git Repos for Project: %s", project.name)
     return git_client.get_repositories(project.id)
 
 
@@ -189,20 +175,12 @@ def get_tfvc_repos(url, token, collection, project):
         token,
     )
 
-    logger.debug(
-        "Retrieving Tfvc Branches for Project: {project_name}".format(
-            project_name=project.name
-        )
-    )
+    logger.debug("Retrieving Tfvc Branches for Project: %s}", project.name)
     branches = tfvc_client.get_branches(project.id, True, True, False, True)
     if branches:
         branch_list.extend(branches)
     else:
-        logger.debug(
-            "No Tfvc Branches in Project: {project_name}".format(
-                project_name=project.name
-            )
-        )
+        logger.debug("No Tfvc Branches in Project: %s", project.name)
 
     return branch_list
 

--- a/scraper/tfs/__init__.py
+++ b/scraper/tfs/__init__.py
@@ -48,8 +48,9 @@ def create_tfs_project_analysis_client(url, token=None):
     )
 
     if project_analysis_client is None:
-        msg = "Unable to connect to TFS Enterprise (%s) with provided token."
-        raise RuntimeError(msg, url)
+        raise RuntimeError(
+            "Unable to connect to TFS Enterprise (%s) with provided token." % url
+        )
 
     return project_analysis_client
 
@@ -68,8 +69,9 @@ def create_tfs_core_client(url, token=None):
     tfs_client = tfs_connection.get_client("vsts.core.v4_1.core_client.CoreClient")
 
     if tfs_client is None:
-        msg = "Unable to connect to TFS Enterprise (%s) with provided token."
-        raise RuntimeError(msg, url)
+        raise RuntimeError(
+            "Unable to connect to TFS Enterprise (%s) with provided token." % url
+        )
 
     return tfs_client
 
@@ -85,8 +87,10 @@ def create_tfs_git_client(url, token=None):
     tfs_git_client = tfs_connection.get_client("vsts.git.v4_1.git_client.GitClient")
 
     if tfs_git_client is None:
-        msg = "Unable to create TFS Git Client, failed to connect to TFS Enterprise (%s) with provided token."
-        raise RuntimeError(msg, url)
+        raise RuntimeError(
+            "Unable to create TFS Git Client, failed to connect to TFS Enterprise (%s) with provided token."
+            % url
+        )
 
     return tfs_git_client
 
@@ -102,8 +106,10 @@ def create_tfs_tfvc_client(url, token=None):
     tfs_tfvc_client = tfs_connection.get_client("vsts.tfvc.v4_1.tfvc_client.TfvcClient")
 
     if tfs_tfvc_client is None:
-        msg = "Unable to create TFS Git Client, failed to connect to TFS Enterprise (%s) with provided token."
-        raise RuntimeError(msg, url)
+        raise RuntimeError(
+            "Unable to create TFS Git Client, failed to connect to TFS Enterprise (%s) with provided token."
+            % url
+        )
 
     return tfs_tfvc_client
 

--- a/scraper/tfs/__init__.py
+++ b/scraper/tfs/__init__.py
@@ -16,7 +16,7 @@ HARD_CODED_TOP = 10000
 
 def get_projects_metadata(baseurl, token):
     logger.debug("Retrieving TFS Metdata.....")
-    return [project for project in get_all_projects(baseurl, token)]
+    return get_all_projects(baseurl, token)
 
 
 def create_tfs_connection(url, token):

--- a/scraper/util.py
+++ b/scraper/util.py
@@ -15,7 +15,7 @@ def execute(command, cwd=None):
     if cwd is None:
         cwd = os.getcwd()
     elif not os.path.isdir(cwd):
-        raise ValueError("path does not exist: %s", cwd)
+        raise ValueError("path does not exist: %s" % cwd)
 
     with Popen(
         command, cwd=cwd, stdout=PIPE, stderr=STDOUT, shell=False


### PR DESCRIPTION
This pull request is an assortment of small changes based on running `pylint` with a default configuration with the following (modified from default) list of disabled checks:

```ini
disable=raw-checker-failed,
        bad-inline-option,
        locally-disabled,
        file-ignored,
        suppressed-message,
        useless-suppression,
        deprecated-pragma,
        use-symbolic-message-instead,
        too-many-arguments,
        too-many-locals,
        too-many-return-statements,
        line-too-long,
        missing-module-docstring,
        missing-class-docstring,
        missing-function-docstring,
        invalid-name,
        too-few-public-methods,
        too-many-branches,
        too-many-instance-attributes,
        too-many-statements,
        fixme,
        consider-using-f-string,
        super-init-not-called,
        protected-access
```

All other items flagged were fixed. I also noticed an issue with how the messages for `raise` calls in `scraper/tfs/__init__.py` were formatted and fixes those while I was making these changes.