### PR TITLE
Update Python version support information

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,9 +1,9 @@
 github3.py>=2.0.0
-python-gitlab>=1.6.0
-stashy>=0.3
-python-dateutil>=2.7.3
-vsts>=0.1.25
-requests>=2.16
 msrest>=0.6.4
+python-dateutil>=2.7.3
+python-gitlab>=1.6.0
 pytz>=2017.3
+requests>=2.16
 setuptools>=24.2.0
+stashy>=0.3
+vsts>=0.1.25

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,3 +6,4 @@ vsts>=0.1.25
 requests>=2.16
 msrest>=0.6.4
 pytz>=2017.3
+setuptools>=24.2.0

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,13 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     url="https://github.com/llnl/scraper",
     packages=find_packages(),
     install_requires=install_reqs,
+    python_requires=">=3.6",
     entry_points={
         "console_scripts": [
             "scraper = scraper.gen_code_gov_json:main",


### PR DESCRIPTION
This pull request updates the supported Python versions for this package to reflect what is currently being tested in the [CI workflow](https://github.com/LLNL/scraper/blob/2412bb184f219b046c329cf6fe29e8ff698578b8/.github/workflows/main.yml). This includes the addition of the [`python_requires`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires) keyword to the `setup()` function and adding the necessary version of [setuptools](https://github.com/pypa/setuptools) to the production requirements. I also updated the classifiers that are included in the package metadata to align with testing and the [list of PyPI classifiers](https://pypi.org/classifiers/).