### PR TITLE
Add handling for empty JSON output from `cloc`

### DIFF
--- a/scraper/code_gov/models.py
+++ b/scraper/code_gov/models.py
@@ -220,9 +220,9 @@ class Project(dict):
 
         project["tags"] = ["github"]
         old_accept = repository.session.headers["Accept"]
-        repository.session.headers[
-            "Accept"
-        ] = "application/vnd.github.mercy-preview+json"
+        repository.session.headers["Accept"] = (
+            "application/vnd.github.mercy-preview+json"
+        )
         topics = repository._get(repository.url + "/topics").json()
         project["tags"].extend(topics.get("names", []))
         repository.session.headers["Accept"] = old_accept

--- a/scraper/util.py
+++ b/scraper/util.py
@@ -148,6 +148,13 @@ def git_repo_to_sloc(url):
         except json.decoder.JSONDecodeError:
             logger.error("Error Decoding: url=%s, out=%s", url, out)
             sloc = 0
+        except KeyError:
+            logging.error(
+                "Missing LOC information (Is the repository empty?): url=%s, json=%s",
+                url,
+                json.dumps(cloc_json),
+            )
+            sloc = 0
 
     logger.debug("SLOC: url=%s, sloc=%d", url, sloc)
 


### PR DESCRIPTION
Starting in version [1.96](https://github.com/AlDanial/cloc/releases/tag/v1.96), [cloc](https://github.com/AlDanial/cloc) will output an empty JSON object (`{}`) instead of nothing if no files are detected. This results in a `KeyError` on empty repositories instead of a `json.decoder.JSONDecodeError`. Since this indicates a potentially different issue it is handled in its own `escept` block. I also had to reformat an otherwise unrelated file to comply with [black](https://github.com/psf/black).