### PR TITLE
Add an upper bound pin for `setuptools`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "python-gitlab>=1.6.0",
     "pytz>=2017.3",
     "requests>=2.16",
-    "setuptools>=24.2.0",
+    "setuptools>=24.2.0,<81",
     "stashy>=0.3",
     "vsts>=0.1.25",
 ]


### PR DESCRIPTION
This is necessary because `scraper` depends on `vsts`, which itself imports the `pkg_resources` package from `setuptools` in its `__init__.py`. The `pkg_resources` package will be removed in `setuptools` 81, which will fundamentally break `vsts` and therefore `scraper`.

I would make the change in `vsts` instead, but that project has changed its name and has undergone several major revisions since:
- [`vsts` on PyPI](https://pypi.org/project/vsts/) (see in particular the homepage link, which redirects to the link in the following bullet)
- [`vsts` on GitHub](https://github.com/microsoft/azure-devops-python-api)

An alternative would be to replace `vsts` with a more modern dependency that serves the same purpose.  `vsts` hasn't seen any updates in [seven years](https://pypi.org/project/vsts/#history).